### PR TITLE
Simplify calculator layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,19 @@
 <style>
   body {
     font-family: Arial, sans-serif;
-    margin: 20px;
-    background: #f2f2f2;
-    color: #000;
+    margin: 10px;
+    background: linear-gradient(135deg, #e0e0ff, #ffe0e0);
+    color: #222;
+  }
+  h1, h2 {
+    color: #2a3d66;
   }
   .slider-container {
-    margin-bottom: 20px;
-    border: 2px solid #000;
-    padding: 12px;
+    margin-bottom: 10px;
+    border: 2px solid #222;
+    padding: 8px;
     background: #fff;
-    box-shadow: 4px 4px 0 #000;
+    box-shadow: 4px 4px 0 #222;
   }
   label {
     display: block;
@@ -27,34 +30,40 @@
     width: 100%;
   }
   #results {
-    margin-top: 30px;
-    border: 2px solid #000;
-    padding: 12px;
+    margin-top: 20px;
+    border: 2px solid #222;
+    padding: 8px;
     background: #fff;
-    box-shadow: 4px 4px 0 #000;
+    box-shadow: 4px 4px 0 #222;
   }
   #resultsTable {
-    margin-top: 30px;
+    margin-top: 20px;
     border-collapse: collapse;
-    border: 2px solid #000;
+    border: 2px solid #222;
     background: #fff;
-    box-shadow: 4px 4px 0 #000;
+    box-shadow: 4px 4px 0 #222;
   }
   #resultsTable th, #resultsTable td {
-    border: 1px solid #000;
+    border: 1px solid #222;
     padding: 4px 8px;
   }
-  #metricsChart {
+  .insights {
+    margin-top: 20px;
+    border: 2px solid #222;
+    padding: 8px;
     background: #fff;
-    border: 2px solid #000;
-    box-shadow: 4px 4px 0 #000;
+    box-shadow: 4px 4px 0 #222;
+  }
+  #calculator {
+    max-width: 600px;
+    margin: 0 auto;
   }
 </style>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
 <h1>CRO Calculator</h1>
+<div id="calculator">
 <div class="slider-container">
   <label for="visitors">Visitors: <span id="visitorsVal">1000</span></label>
   <input type="range" id="visitors" min="0" max="10000" value="1000" step="10">
@@ -98,9 +107,17 @@
   </tbody>
 </table>
 
-<canvas id="metricsChart" width="500" height="250"></canvas>
+<div class="insights">
+  <h2>What the numbers mean</h2>
+  <p><strong>Paying Customers:</strong> expected subscribers based on your traffic and conversion rate.</p>
+  <p><strong>MRR:</strong> predictable monthly revenue from those customers.</p>
+  <p><strong>ARR:</strong> yearly subscription revenue calculated from MRR.</p>
+  <p><strong>Payback Period:</strong> months needed to recover your acquisition costs.</p>
+  </div>
+
+</div>
+
 <script>
-let chart;
 function update() {
   const visitors = parseInt($('#visitors').val());
   const conversion = parseFloat($('#conversion').val()) / 100;
@@ -135,72 +152,9 @@ function update() {
   $('#mrrTab').text(`$${mrr.toFixed(2)}`);
   $('#arrTab').text(`$${arr.toFixed(2)}`);
   $('#paybackTab').text(payback.toFixed(2));
-
-  updateChart(visitors, conversion, price, cpc);
-}
-
-function updateChart(visitors, conversion, price, cpc) {
-  const steps = 10;
-  const step = visitors / steps;
-  const labels = [];
-  const mrrData = [];
-  const acquisitionData = [];
-  const paybackData = [];
-  for (let i = 0; i <= steps; i++) {
-    const v = step * i;
-    const customers = v * conversion;
-    const mrr = customers * price;
-    const acquisition = v * cpc;
-    const payback = mrr > 0 ? acquisition / mrr : 0;
-    labels.push(Math.round(v));
-    mrrData.push(mrr);
-    acquisitionData.push(acquisition);
-    paybackData.push(payback);
-  }
-
-  chart.data.labels = labels;
-  chart.data.datasets[0].data = mrrData;
-  chart.data.datasets[1].data = acquisitionData;
-  chart.data.datasets[2].data = paybackData;
-  chart.update();
 }
 
 $(function() {
-  const ctx = document.getElementById('metricsChart').getContext('2d');
-  chart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: [],
-      datasets: [
-        { label: 'MRR', borderColor: 'blue', fill: false, data: [], yAxisID: 'y', pointRadius: 3, pointHoverRadius: 5 },
-        { label: 'Acquisition Cost', borderColor: 'green', fill: false, data: [], yAxisID: 'y', pointRadius: 3, pointHoverRadius: 5 },
-        { label: 'Payback Period', borderColor: 'red', fill: false, data: [], yAxisID: 'y2', pointRadius: 3, pointHoverRadius: 5 }
-      ]
-    },
-    options: {
-      interaction: { mode: 'index', intersect: false },
-      hover: { mode: 'index', intersect: false },
-      plugins: {
-        legend: { display: true },
-        tooltip: { mode: 'index', intersect: false }
-      },
-      scales: {
-        x: { title: { display: true, text: 'Visitors' } },
-        y: {
-          beginAtZero: true,
-          position: 'left',
-          title: { display: true, text: 'Revenue / Cost ($)' }
-        },
-        y2: {
-          beginAtZero: true,
-          position: 'right',
-          grid: { drawOnChartArea: false },
-          title: { display: true, text: 'Payback Period (months)' }
-        }
-      }
-    }
-  });
-
   $('input[type=range]').on('input', function() {
     update();
   });


### PR DESCRIPTION
## Summary
- remove graph and Chart.js dependency
- wrap sliders and results in a compact calculator container
- add concise explanations of each metric
- apply a colorful gradient style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68818c1ed71c8327a0459ff0a2c51d38