### PR TITLE
Add profit controls and center layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   }
   h1, h2 {
     color: #2a3d66;
+    text-align: center;
   }
   .slider-container {
     margin-bottom: 10px;
@@ -20,18 +21,20 @@
     box-shadow: 4px 4px 0 #222;
   }
   .description {
-    margin: 10px 0;
+    margin: 10px auto;
     border: 2px solid #222;
     padding: 8px;
     background: #fff;
     box-shadow: 4px 4px 0 #222;
     max-width: 600px;
+    text-align: center;
   }
   #calculator {
     display: flex;
     gap: 20px;
     max-width: 800px;
     margin: 0 auto;
+    text-align: center;
   }
   #inputs, #outputs {
     flex: 1;
@@ -41,6 +44,7 @@
   .color3 { background: #fdffb6; }
   .color4 { background: #caffbf; }
   .color5 { background: #9bf6ff; }
+  .color6 { background: #ffc6ff; }
   label {
     display: block;
     font-weight: bold;
@@ -78,8 +82,8 @@
 <div id="inputs">
 <div class="slider-container color1">
   <label for="visitors">Visitors: <span id="visitorsVal">1000</span></label>
-  <input type="range" id="visitors" min="0" max="10000" value="1000" step="10">
-  <input type="number" id="visitorsNum" min="0" max="10000" value="1000" step="10">
+  <input type="range" id="visitors" min="0" max="10000" value="1000" step="1">
+  <input type="number" id="visitorsNum" min="0" max="10000" value="1000" step="1">
 </div>
 <div class="slider-container color2">
   <label for="conversion">Conversion Rate (%): <span id="conversionVal">5</span></label>
@@ -101,6 +105,11 @@
   <input type="range" id="cpc" min="0" max="10" value="0.50" step="0.01">
   <input type="number" id="cpcNum" min="0" max="10" value="0.50" step="0.01">
 </div>
+<div class="slider-container color6">
+  <label for="margin">Profit Margin (%): <span id="marginVal">50</span></label>
+  <input type="range" id="margin" min="0" max="100" value="50">
+  <input type="number" id="marginNum" min="0" max="100" value="50">
+</div>
 </div> <!-- end inputs -->
 <div id="outputs">
 <table id="resultsTable">
@@ -112,6 +121,8 @@
     <tr><td>Monthly Recurring Revenue (MRR)</td><td id="mrrTab">$250.00</td></tr>
     <tr><td>Annual Recurring Revenue (ARR)</td><td id="arrTab">$3000.00</td></tr>
     <tr><td>Payback Period (months)</td><td id="paybackTab">2.00</td></tr>
+    <tr><td>Advertising Spend</td><td id="spendTab">$500.00</td></tr>
+    <tr><td>Profit</td><td id="profitTab">$0.00</td></tr>
   </tbody>
 </table>
 
@@ -121,6 +132,9 @@
   <p><strong>Monthly Recurring Revenue (MRR):</strong> predictable monthly revenue from those customers.</p>
   <p><strong>Annual Recurring Revenue (ARR):</strong> yearly subscription revenue calculated from MRR.</p>
   <p><strong>Payback Period:</strong> months needed to recover your acquisition costs.</p>
+  <p><strong>Profit Margin:</strong> percent of revenue kept after non-advertising costs.</p>
+  <p><strong>Advertising Spend:</strong> total money spent on ads based on visitor volume and cost per visitor.</p>
+  <p><strong>Profit:</strong> revenue remaining after advertising spend and your chosen profit margin.</p>
   </div>
 
 </div>
@@ -133,23 +147,27 @@ function update() {
   const price = parseFloat($('#price').val());
   const retention = parseInt($('#retention').val());
   const cpc = parseFloat($('#cpc').val());
+  const margin = parseFloat($('#margin').val());
 
   $('#visitorsNum').val(visitors);
   $('#conversionNum').val($('#conversion').val());
   $('#priceNum').val(price);
   $('#retentionNum').val(retention);
   $('#cpcNum').val(cpc);
+  $('#marginNum').val(margin);
 
   $('#visitorsVal').text(visitors);
   $('#conversionVal').text((conversion * 100).toFixed(1));
   $('#priceVal').text(price.toFixed(2));
   $('#retentionVal').text(retention);
   $('#cpcVal').text(cpc.toFixed(2));
+  $('#marginVal').text(margin.toFixed(0));
 
   const customers = visitors * conversion;
   const mrr = customers * price;
   const arr = mrr * 12;
   const acquisitionCost = visitors * cpc;
+  const profit = mrr * (margin / 100) - acquisitionCost;
   const payback = mrr > 0 ? acquisitionCost / mrr : 0;
 
 
@@ -157,6 +175,8 @@ function update() {
   $('#mrrTab').text(`$${mrr.toFixed(2)}`);
   $('#arrTab').text(`$${arr.toFixed(2)}`);
   $('#paybackTab').text(payback.toFixed(2));
+  $('#spendTab').text(`$${acquisitionCost.toFixed(2)}`);
+  $('#profitTab').text(`$${profit.toFixed(2)}`);
 }
 
 $(function() {
@@ -164,7 +184,7 @@ $(function() {
     update();
   });
 
-  $('input[type=number]').on('input', function() {
+  $('input[type=number]').on('change keyup', function() {
     const id = $(this).attr('id').replace('Num', '');
     $('#' + id).val($(this).val());
     update();


### PR DESCRIPTION
## Summary
- center align calculator headings and description
- allow numeric inputs to be typed freely
- add profit margin slider
- show advertising spend and profit in the results table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68819562cb3883279e3d636ebde10c17